### PR TITLE
best fix at the moment for footer floating over content on home

### DIFF
--- a/src/components/googleMapsNpm/googleMaps.jsx
+++ b/src/components/googleMapsNpm/googleMaps.jsx
@@ -246,6 +246,7 @@ class GoogleMaps extends Component {
     console.log(this.state.selectedPlace, "selected place!!");
     return (
       <div
+        className="home"
       // style={{ display: "flex", flexDirection: "flexEnd", flexWrap: "wrap" }}
       >
         <CpForm
@@ -325,9 +326,7 @@ class GoogleMaps extends Component {
           </Map>
         )}
         <Carousel />
-        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
-        <br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />
+        
       </div>
     );
   }

--- a/src/components/googleMapsNpm/home.css
+++ b/src/components/googleMapsNpm/home.css
@@ -1,0 +1,3 @@
+.home {
+    min-height: 1300px;
+}


### PR DESCRIPTION
The browser thinks google maps has a height of zero which makes the footer float up over content on home page. Cant figure it out. Set a min height for the home page stuff to push footer down but dont think it will work for different size windows